### PR TITLE
fix compose.yml minioのcommandが重複しないように修正

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -74,7 +74,6 @@ services:
       MINIO_ROOT_USER: ${AWS_ACCESS_KEY_ID}
       MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY}
       MINIO_CONSOLE_ADDRESS: ":9090"
-    command: server /data
     entrypoint: sh
     command: -c 'mkdir -p /data/bucket && /opt/bin/minio server /data'
 


### PR DESCRIPTION
minioの定義でcommandが重複しているため起動できなかったので片方削除しました。

修正前
```
$ make
docker compose up -d
yaml: unmarshal errors:
  line 79: mapping key "command" already defined at line 77
make: *** [Makefile:6: start] Error 15
```

修正後
```
$ make
docker compose up -d
[+] Running 6/10
 ⠦ Network iceberg-sandbox-kit_default           Created                  12.6s
 ⠦ Volume "iceberg-sandbox-kit_trino-data"       Created                  12.6s
 ⠦ Volume "iceberg-sandbox-kit_rest-mysql-data"  Created                  12.5s
 ⠦ Volume "iceberg-sandbox-kit_minio-data"       Created                  12.5s
 ✔ Container iceberg-sandbox-kit-trino-1         Started                   0.7s
 ✔ Container iceberg-sandbox-kit-minio-1         Started                   1.2s
 ✔ Container iceberg-sandbox-kit-mitmproxy-1     Started                   1.2s
 ✔ Container iceberg-sandbox-kit-mysql-1         Healthy                  12.3s
 ✔ Container iceberg-sandbox-kit-rest-1          Started                  12.5s
 ✔ Container iceberg-sandbox-kit-debug-1         Started                   1.4s
# Service started!
# Trino: http://localhost:8080 / User: dummy
# Minio: http://localhost:9000 / User: admin / Password: password
```