### PR TITLE
Arm64 Mac 上でも動作できるようにしたい

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include .env
 
-.PHONY: start stop clean trino minio mysql debug
+.PHONY: start stop clean trino minio mysql debug build init-table insert-row
 
 start:
 	docker compose up -d
@@ -25,3 +25,12 @@ mysql:
 
 debug:
 	docker compose exec debug bash
+
+build:
+	docker compose build
+
+init-table:
+	docker compose exec trino trino --catalog iceberg --schema default --execute "CREATE SCHEMA IF NOT EXISTS default; USE default; CREATE TABLE IF NOT EXISTS t1 (a int, b int);"
+
+insert-row:
+	docker compose exec trino trino --catalog iceberg --schema default --execute "USE default; INSERT INTO t1 VALUES (1, 2); SELECT * FROM t1;"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ start:
 	docker compose up -d
 	# Service started!
 	# Trino: http://localhost:8080 / User: dummy
-	# Minio: http://localhost:9000 / User: ${AWS_ACCESS_KEY_ID} / Password: ${AWS_SECRET_ACCESS_KEY}
+	# Minio: http://localhost:9090 / User: ${AWS_ACCESS_KEY_ID} / Password: ${AWS_SECRET_ACCESS_KEY}
 
 stop:
 	docker compose stop

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ make debug  # デバッグ用コンテナが起動
 root@debug:/mnt/s3# tree
 root@debug:/mnt/s3# jq '.' default/t1-XXXX/metadata/0000X-XXXX.metadata.json
 root@debug:/mnt/s3# avrocat default/t1-XXXX/metadata/snap-XXXX.avro | jq '.'
-root@debug:/mnt/s3# duckdb -c "SELECT * FROM 'default/t1-XXXX/data/2025....XXXX.parquet'"
+root@debug:/mnt/s3# pqrs cat default/t1-XXXX/data/2025....XXXX.parquet
 ```
 
 ## 5. View the MitM Proxy logs

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Iceberg で利用される主なフォーマットである、JSON,Avro,Parquet 
 $ make debug  # デバッグ用コンテナが起動
 
 root@debug:/mnt/s3# tree
-root@debug:/mnt/s3# jq '.' default/t1/metadata/00001-5e8f....ea99.metadata.json
-root@debug:/mnt/s3# avrocat default/t1/metadata/snap-8429...ef78.avro | jq '.'
-root@debug:/mnt/s3# pqrs cat default/t1/data/2023....a688.parquet
+root@debug:/mnt/s3# jq '.' default/t1-XXXX/metadata/0000X-XXXX.metadata.json
+root@debug:/mnt/s3# avrocat default/t1-XXXX/metadata/snap-XXXX.avro | jq '.'
+root@debug:/mnt/s3# duckdb -c "SELECT * FROM 'default/t1-XXXX/data/2025....XXXX.parquet'"
 ```
 
 ## 5. View the MitM Proxy logs
@@ -86,9 +86,9 @@ http://localhost:8081/
 `make trino` で CLI を開いていくつかのデータを Insert したあと、以下のような最適化コマンドでメタデータ・データがどう変化するかを確認します。
 
 ```sql
-ALTER TABLE example EXECUTE optimize(file_size_threshold => '10MB');
-ALTER TABLE example EXECUTE expire_snapshots(retention_threshold => '7d');
-ALTER TABLE example EXECUTE remove_orphan_files(retention_threshold => '7d');
+ALTER TABLE t1 EXECUTE optimize(file_size_threshold => '10MB');
+ALTER TABLE t1 EXECUTE expire_snapshots(retention_threshold => '7d');
+ALTER TABLE t1 EXECUTE remove_orphan_files(retention_threshold => '7d');
 ```
 
 ## 7. Cleanup

--- a/compose.yaml
+++ b/compose.yaml
@@ -45,7 +45,7 @@ services:
       - CATALOG_JDBC_PASSWORD=${REST_CATALOG_DB_PASSWORD}
 
   mysql:
-    image: mysql:8.0-debian
+    image: mysql:8.0
     restart: unless-stopped
     volumes:
       - rest-mysql-data:/var/lib/mysql
@@ -84,7 +84,7 @@ services:
     volumes:
       - ./mitmproxy:/home/mitmproxy/.mitmproxy
     command: mitmweb --web-host 0.0.0.0
-  
+
   debug:
     # minio storage is mounted and tools such as avro cli, pqrs(parquet read cli), and jq are installed.
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -28,12 +28,12 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_REGION=us-east-1
       - HTTP_PROXY=http://mitmproxy:8080
-      # has prefix "CATALOG_" variable convert rules
-      # impl: https://github.com/tabular-io/iceberg-rest-image/blob/master/src/main/java/org/apache/iceberg/rest/RESTCatalogServer.java
-      # 1. remove prefix "CATALOG_"
-      # 2. replace "__" to "-"
-      # 3. replace "_" to "."
-      # 4. convert to lower case
+      # Environment variables prefixed by CATALOG_ are passed through the catalog configuring with the following mutations:
+      # docs: https://github.com/apache/iceberg/blob/main/open-api/README.md
+      # 1. The CATALOG_ prefix is stripped from the key name
+      # 2. Single underscore (_) is replaced with a dot (.)
+      # 3. Double underscore (__) is replaced with a dash (-)
+      # 4. The key names are converted to lowercase
       - CATALOG_WAREHOUSE=s3://bucket/
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_PATH__STYLE__ACCESS=true

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
 
   rest:
     # Fix to add MySQL driver to original image
-    # image: tabulario/iceberg-rest:0.6.0
+    # image: apache/iceberg-rest-fixture:1.8.1
     build:
       context: ./rest-catalog/
       dockerfile: Dockerfile
@@ -44,7 +44,7 @@ services:
       - CATALOG_JDBC_PASSWORD=${REST_CATALOG_DB_PASSWORD}
 
   mysql:
-    image: mysql:8.0
+    image: mysql:9.2
     restart: unless-stopped
     volumes:
       - rest-mysql-data:/var/lib/mysql
@@ -62,7 +62,7 @@ services:
       retries: 30
 
   minio:
-    image: minio/minio:RELEASE.2023-09-23T03-47-50Z
+    image: minio/minio:RELEASE.2025-03-12T18-04-18Z
     ports:
       - 9000:9000
       - 9090:9090
@@ -74,10 +74,10 @@ services:
       MINIO_ROOT_PASSWORD: ${AWS_SECRET_ACCESS_KEY}
       MINIO_CONSOLE_ADDRESS: ":9090"
     entrypoint: sh
-    command: -c 'mkdir -p /data/bucket && /opt/bin/minio server /data'
+    command: -c 'mkdir -p /data/bucket && minio server /data'
 
   mitmproxy:
-    image: mitmproxy/mitmproxy:10.1.1
+    image: mitmproxy/mitmproxy:11.1.3
     ports:
       - 8081:8081
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.4"
 services:
   trino:
     image: trinodb/trino:427

--- a/debug/Dockerfile
+++ b/debug/Dockerfile
@@ -12,10 +12,8 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
-RUN wget https://github.com/manojkarthick/pqrs/releases/download/v0.3.1/pqrs-0.3.1-x86_64-unknown-linux-gnu.zip \
-  && unzip pqrs-0.3.1-x86_64-unknown-linux-gnu.zip \
-  && mv ./pqrs-0.3.1-x86_64-unknown-linux-gnu/bin/pqrs /usr/local/bin/pqrs \
-  && rm -rf pqrs-0.3.1-x86_64-unknown-linux-gnu.zip pqrs-0.3.1-x86_64-unknown-linux-gnu
+RUN curl https://install.duckdb.org | sh
+ENV PATH="/root/.duckdb/cli/latest:${PATH}"
 
 COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY ./run.sh /usr/local/bin/run.sh

--- a/debug/Dockerfile
+++ b/debug/Dockerfile
@@ -12,8 +12,11 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp
-RUN curl https://install.duckdb.org | sh
-ENV PATH="/root/.duckdb/cli/latest:${PATH}"
+RUN ARCH=$(uname -m) && \
+  wget "https://github.com/manojkarthick/pqrs/releases/download/v0.3.2/pqrs-0.3.2-${ARCH}-unknown-linux-gnu.zip" -O pqrs.zip; \
+  unzip pqrs.zip && \
+  mv ./pqrs-*/bin/pqrs /usr/local/bin/pqrs && \
+  rm -rf pqrs.zip pqrs-*
 
 COPY ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY ./run.sh /usr/local/bin/run.sh

--- a/rest-catalog/Dockerfile
+++ b/rest-catalog/Dockerfile
@@ -1,6 +1,6 @@
-FROM tabulario/iceberg-rest:0.6.0
+FROM apache/iceberg-rest-fixture:1.8.1
 
-ENV URL=https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar
+ENV URL=https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.2.0/mysql-connector-j-9.2.0.jar
 ADD --chown=iceberg:iceberg ${URL} /usr/lib/iceberg-rest/
 
 CMD ["java", "-classpath", "/usr/lib/iceberg-rest/*", "org.apache.iceberg.rest.RESTCatalogServer"]


### PR DESCRIPTION
# 概要
Arm64 Mac 上でも動作するようにしたい。
ついでに docker イメージを最新化する。

# 変更点
<!-- 主な変更点を箇条書きで記載してください -->
- x86_64 しかサポートしていないイメージやバイナリを代替する
- REST Catalog に使うイメージをメンテが継続されているものに移行（`tabulario/iceberg-rest` → `apache/iceberg-rest-fixture`）
- その他 docker image を最新バージョンにアップデート
- テーブル作成・行インサートを簡易的に行う make target の追加
- README の修正

# 関連Issue
- 取り込み済み Issue
  -  #1

# 動作確認
<details><summary>テーブルの作成 & 行インサートに成功すること</summary>

```
~/ghq/github.com/kmikmy/iceberg-sandbox-kit $ make
docker compose up -d
[+] Running 10/10
 ✔ Network iceberg-sandbox-kit_default           Created                                                                                                                                           0.1s 
 ✔ Volume "iceberg-sandbox-kit_trino-data"       Created                                                                                                                                           0.0s 
 ✔ Volume "iceberg-sandbox-kit_rest-mysql-data"  Created                                                                                                                                           0.0s 
 ✔ Volume "iceberg-sandbox-kit_minio-data"       Created                                                                                                                                           0.0s 
 ✔ Container iceberg-sandbox-kit-mitmproxy-1     Started                                                                                                                                           0.5s 
 ✔ Container iceberg-sandbox-kit-minio-1         Started                                                                                                                                           0.4s 
 ✔ Container iceberg-sandbox-kit-mysql-1         Healthy                                                                                                                                           5.9s 
 ✔ Container iceberg-sandbox-kit-trino-1         Started                                                                                                                                           0.5s 
 ✔ Container iceberg-sandbox-kit-rest-1          Started                                                                                                                                           5.9s 
 ✔ Container iceberg-sandbox-kit-debug-1         Started                                                                                                                                           0.5s 
# Service started!
# Trino: http://localhost:8080 / User: dummy
# Minio: http://localhost:9090 / User: admin / Password: password
~/ghq/github.com/kmikmy/iceberg-sandbox-kit $ make init-table
docker compose exec trino trino --catalog iceberg --schema default --execute "CREATE SCHEMA IF NOT EXISTS default; USE default; CREATE TABLE IF NOT EXISTS t1 (a int, b int);"
CREATE SCHEMA
USE
CREATE TABLE
~/ghq/github.com/kmikmy/iceberg-sandbox-kit $ make insert-row
docker compose exec trino trino --catalog iceberg --schema default --execute "USE default; INSERT INTO t1 VALUES (1, 2); SELECT * FROM t1;"
USE
INSERT: 1 row
"1","2"
~/ghq/github.com/kmikmy/iceberg-sandbox-kit $ 
```

</details>

# 備考
- レビューして欲しい点
  - 修正内容に懸念がないか
  - 動作確認に不足がないか